### PR TITLE
php 8.5 + reset and flush methods

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.4', '8.2', '8.3', '8.4']
+        php-versions: ['7.4', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Checkout

--- a/php_trochilidae.h
+++ b/php_trochilidae.h
@@ -22,6 +22,7 @@
 
 ZEND_BEGIN_MODULE_GLOBALS(trochilidae)
     bool enabled;
+    bool flashed;
     bool modeCli;
     char *server_list;
     char hostName[HOST_NAME_MAX];

--- a/test.php
+++ b/test.php
@@ -8,31 +8,11 @@ echo 'trochilidae.enabled: ', ini_get('trochilidae.enabled'), PHP_EOL;
 // ini_set('trochilidae.server_list', 'localhost,192.168.1.2:999');
 ini_set('trochilidae.server_list', 'localhost');
 echo 'trochilidae.server_list: ', ini_get('trochilidae.server_list'), PHP_EOL;
-
-function generateRandomString($length = 10) {
-//     $characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-//     $charactersLength = strlen($characters);
-//     $randomString = '';
-//
-//     for ($i = 0; $i < $length; $i++) {
-//         $randomString .= $characters[random_int(0, $charactersLength - 1)];
-//     }
-
-//     return bin2hex(random_bytes($length));
-    return bin2hex(random_bytes($length));
-//     return $randomString;
-}
+ini_set('trochilidae.server_list', 'localhost,192.168.1.2:999');
 
 trochilidae_set_tag("controller", "testController");
 trochilidae_set_tag("action", "testAction");
-trochilidae_set_tag("company", $company = "testCompany");
-// trochilidae_set_tag("testMemory", bin2hex(random_bytes(1024*64)));
-// trochilidae_set_tag("testMemory", generateRandomString(1024*1*1024));
-// trochilidae_set_tag("testMemory", generateRandomString(64*1024/32));
-// trochilidae_set_tag("testMemoryX", str_repeat("testRepeat", 1024*10));
-// trochilidae_set_tag("testMemoryBytes", random_bytes(1024*1024*2));
-trochilidae_set_tag("convertTest", 654);
-trochilidae_set_tag("ruTest", "Бу, испугался? не бойся.");
+trochilidae_set_tag("company", "testCompany");
 
 echo 'trochilidae_timer_stop', PHP_EOL;
 $r = trochilidae_timer_stop("db");
@@ -54,9 +34,17 @@ echo 'trochilidae_timer_stop', PHP_EOL;
 
 var_dump(trochilidae_timer_get_info());
 
-$hostname = bin2hex(random_bytes(256*1024));
-// echo "trochilidae_set_hostname('$hostname')", PHP_EOL;
-// trochilidae_set_hostname('test');
-// trochilidae_set_hostname($hostname);
+$hostname = bin2hex(random_bytes(68));
+echo "trochilidae_set_hostname('$hostname')", PHP_EOL;
+trochilidae_set_hostname('test');
+trochilidae_set_hostname($hostname);
 
-echo 'OK: ', memory_get_peak_usage(true) / 1024 / 1024 , 'Mb', PHP_EOL;
+for ($i = 0; $i < 1000; $i++) {
+    trochilidae_reset();
+    trochilidae_timer_start("random");
+    $hostname = bin2hex(random_bytes(4));
+    trochilidae_timer_stop("random");
+    trochilidae_flush();
+}
+
+echo 'OK, mem: ', memory_get_peak_usage(true) / 1024/ 1024, "Mb" , PHP_EOL;

--- a/trochilidae.c
+++ b/trochilidae.c
@@ -117,6 +117,16 @@ PHP_FUNCTION(trochilidae_timer_stop) {
     RETURN_TRUE;
 }
 
+PHP_FUNCTION(trochilidae_flush) {
+    tr_flush();
+    RETURN_TRUE;
+}
+
+PHP_FUNCTION(trochilidae_reset) {
+    tr_reset();
+    RETURN_TRUE;
+}
+
 static PHP_FUNCTION(trochilidae_timer_get_info) {
     array_init(return_value);
     zend_ulong idx;
@@ -143,6 +153,8 @@ static const zend_function_entry functions[] = {
     PHP_FE(trochilidae_set_hostname, arginfo_trochilidae_set_hostname)
     PHP_FE(trochilidae_timer_start, arginfo_trochilidae_timer_start)
     PHP_FE(trochilidae_timer_stop, arginfo_trochilidae_timer_stop)
+    PHP_FE(trochilidae_flush, arginfo_trochilidae_flush)
+    PHP_FE(trochilidae_reset, arginfo_trochilidae_reset)
     PHP_FE(trochilidae_timer_get_info, arginfo_trochilidae_get_info)
     PHP_FE_END
 };
@@ -183,18 +195,32 @@ static PHP_MSHUTDOWN_FUNCTION(trochilidae) {
 }
 
 static PHP_RINIT_FUNCTION(trochilidae) {
+    tr_reset();
+    return SUCCESS;
+}
+
+static PHP_RSHUTDOWN_FUNCTION(trochilidae) {
+     tr_flush();
+    return SUCCESS;
+}
+
+static int tr_reset() {
+    TR_G(flashed) = false;
     collect_metrics_before_request();
+    zval_dtor(&TR_G(tags));
+    zval_dtor(&TR_G(timers));
     array_init(&TR_G(tags));
     array_init(&TR_G(timers));
     return SUCCESS;
 }
 
-static PHP_RSHUTDOWN_FUNCTION(trochilidae) {
-    if (TR_G(enabled) != false) {
-        send_data();
+static int tr_flush() {
+    if (TR_G(enabled) == false || TR_G(flashed) == true) {
+        return SUCCESS;
     }
-    zval_ptr_dtor(&TR_G(tags));
-    zval_ptr_dtor(&TR_G(timers));
+
+    TR_G(flashed) = true;
+    send_data();
     return SUCCESS;
 }
 

--- a/trochilidae_arginfo.h
+++ b/trochilidae_arginfo.h
@@ -25,6 +25,8 @@ static void tr_client_w_argvs(size_t *pos);
 
 static int tr_client_init_or_error(TrClient *client);
 
+static int tr_flush();
+static int tr_reset();
 static int send_data();
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_trochilidae_set_tag, 0, 0, 2)
@@ -42,6 +44,12 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_trochilidae_timer_stop, 0, 0, 0)
     ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_trochilidae_reset, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_trochilidae_flush, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_trochilidae_get_info, 0, 0, 0)


### PR DESCRIPTION
new php methods:
- trochilidae_reset
- trochilidae_flush

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые функции**
  * Добавлены команды для ручного сброса состояния и отправки накопленных данных.
  * Расширена поддержка PHP-версий в сборке, включая новые актуальные версии.

* **Изменения в работе**
  * Обновлён порядок обработки запросов: данные теперь отправляются более предсказуемо в конце запроса.
  * Улучшена работа с сетевыми настройками и тестовым сценарием с многократными короткими запросами.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->